### PR TITLE
Increase max heap size for stockmanagement in prod and restart on memory crash

### DIFF
--- a/deployment/production_env/docker-compose.yml
+++ b/deployment/production_env/docker-compose.yml
@@ -35,41 +35,46 @@ services:
     image: openlmis/requisition:${OL_REQUISITION_VERSION}
     env_file: settings.env
     environment:
-      JAVA_OPTS: '-server -Xmx1024m -Dlogging.config=/config/log/logback.xml'
+      JAVA_OPTS: '-server -Xmx1024m -Dlogging.config=/config/log/logback.xml -XX:+CrashOnOutOfMemoryError
     volumes:
       - 'syslog:/var/log'
       - 'service-config:/config'
     depends_on: [log]
+    restart: on-failure
 
   referencedata:
     image: openlmis/referencedata:${OL_REFERENCEDATA_VERSION}
     env_file: settings.env
     environment:
-      JAVA_OPTS: '-server -Xmx1024m -Dlogging.config=/config/log/logback.xml'
+      JAVA_OPTS: '-server -Xmx1024m -Dlogging.config=/config/log/logback.xml -XX:+CrashOnOutOfMemoryError'
     volumes:
       - 'syslog:/var/log'
       - 'service-config:/config'
     depends_on: [log]
+    restart: on-failure
 
   auth:
     image: openlmis/auth:${OL_AUTH_VERSION}
     env_file: settings.env
     environment:
-      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml'
+      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml -XX:+CrashOnOutOfMemoryError'
     volumes:
       - 'syslog:/var/log'
       - 'service-config:/config'
     depends_on: [log]
+    restart: on-failure
 
   notification:
     image: openlmis/notification:${OL_NOTIFICATION_VERSION}
     env_file: settings.env
     environment:
-      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml'
+      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml -XX:+CrashOnOutOfMemoryError'
     volumes:
       - 'syslog:/var/log'
       - 'service-config:/config'
     depends_on: [log]
+    restart: on-failure
+
   selv-v3-extensions:
     image: openlmismz/selv-v3-extensions-config:1.0.0
     volumes:
@@ -85,32 +90,35 @@ services:
       - 'syslog:/var/log'
       - 'service-config:/config'
     depends_on: [log]
+    restart: on-failure
 
   stockmanagement:
     image: openlmis/stockmanagement:${OL_STOCKMANAGEMENT_VERSION}
     env_file: settings.env
     environment:
-      JAVA_OPTS: '-server -Xmx2048m -Dlogging.config=/config/log/logback.xml'
+      JAVA_OPTS: '-server -Xmx2048m -Dlogging.config=/config/log/logback.xml -XX:+CrashOnOutOfMemoryError'
     volumes:
       - 'syslog:/var/log'
       - 'service-config:/config'
     depends_on: [log]
+    restart: on-failure
 
   cce:
     image: openlmis/cce:${OL_CCE_VERSION}
     env_file: settings.env
     environment:
-      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml'
+      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml -XX:+CrashOnOutOfMemoryError'
     volumes:
       - 'syslog:/var/log'
       - 'service-config:/config'
     depends_on: [log]
+    restart: on-failure
 
   equipment:
     image: openlmismz/equipment:${OL_EQUIPMENT_VERSION}
     env_file: settings.env
     environment:
-      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml'
+      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml -XX:+CrashOnOutOfMemoryError'
     volumes:
       - 'syslog:/var/log'
       - 'service-config:/config'
@@ -120,44 +128,48 @@ services:
     image: openlmismz/requisition-batch:${OL_REQUISITION_BATCH_VERSION}
     env_file: settings.env
     environment:
-      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml'
+      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml -XX:+CrashOnOutOfMemoryError'
     volumes:
       - 'syslog:/var/log'
       - 'service-config:/config'
     depends_on: [log]
+    restart: on-failure
 
   report:
     image: openlmismz/selv-v3-report:${OL_REPORT_VERSION}
     env_file: settings.env
     environment:
-      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml'
+      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml -XX:+CrashOnOutOfMemoryError'
     volumes:
       - 'syslog:/var/log'
       - 'service-config:/config'
     depends_on: [log]
+    restart: on-failure
 
   hapifhir:
     restart: always
     image: openlmis/hapifhir:${OL_HAPIFHIR_VERSION}
     env_file: settings.env
     environment:
-      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml'
+      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml -XX:+CrashOnOutOfMemoryError'
       spring_profiles_active: ${spring_profiles_active}
     volumes:
       - 'syslog:/var/log'
       - 'service-config:/config'
     depends_on: [log]
+    restart: on-failure
 
   diagnostics:
     image: openlmis/diagnostics:${OL_DIAGNOSTICS_VERSION}
     env_file: settings.env
     environment:
-      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml'
+      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml -XX:+CrashOnOutOfMemoryError'
       spring_profiles_active: ${spring_profiles_active}
     volumes:
       - 'service-config:/config'
       - 'syslog:/var/log'
     depends_on: [log]
+    restart: on-failure
 
 ## Data-pumps related services are temporary disabled
 #  zookeeper:

--- a/deployment/production_env/docker-compose.yml
+++ b/deployment/production_env/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     image: openlmis/requisition:${OL_REQUISITION_VERSION}
     env_file: settings.env
     environment:
-      JAVA_OPTS: '-server -Xmx1024m -Dlogging.config=/config/log/logback.xml -XX:+CrashOnOutOfMemoryError
+      JAVA_OPTS: '-server -Xmx1024m -Dlogging.config=/config/log/logback.xml -XX:+CrashOnOutOfMemoryError'
     volumes:
       - 'syslog:/var/log'
       - 'service-config:/config'

--- a/deployment/production_env/docker-compose.yml
+++ b/deployment/production_env/docker-compose.yml
@@ -90,7 +90,7 @@ services:
     image: openlmis/stockmanagement:${OL_STOCKMANAGEMENT_VERSION}
     env_file: settings.env
     environment:
-      JAVA_OPTS: '-server -Xmx512m -Dlogging.config=/config/log/logback.xml'
+      JAVA_OPTS: '-server -Xmx2048m -Dlogging.config=/config/log/logback.xml'
     volumes:
       - 'syslog:/var/log'
       - 'service-config:/config'


### PR DESCRIPTION
Temporary fix in order to prevent Java Heap size memory errors.
They are caused by the UI requestign Integer.MAX number of valid destination
sources (this can be around 70k records). This is temporary fix
designed to keep the production going without such errors until the code
gets refactored.

Second change:

On memory failure, crash and restart

This is a band-aid fix for the issues we are seeing with memory errors.
In order to avoid a container with a corrupted JVM, we kill the Java
process and rely on Docker to restart the container.