### PR TITLE
Update Scalyr Agent version

### DIFF
--- a/deployment/dev_env/docker-compose.yml
+++ b/deployment/dev_env/docker-compose.yml
@@ -246,7 +246,7 @@ services:
       - consul
 
   scalyr:
-    image: openlmis/scalyr
+    image: openlmis/scalyr:${OL_SCALYR_AGENT_VERSION}
     container_name: scalyr-agent
     env_file: settings.env
     volumes:

--- a/deployment/production_env/docker-compose.yml
+++ b/deployment/production_env/docker-compose.yml
@@ -258,7 +258,7 @@ services:
       - consul
 
   scalyr:
-    image: openlmis/scalyr
+    image: openlmis/scalyr:${OL_SCALYR_AGENT_VERSION}
     container_name: scalyr-agent
     env_file: settings.env
     volumes:

--- a/deployment/production_reporting_env/nifi-registry/.env
+++ b/deployment/production_reporting_env/nifi-registry/.env
@@ -1,6 +1,6 @@
 OL_NIFI_REGISTRY_VERSION=0.2.0
 OL_RSYSLOG_VERSION=1
-OL_SCALYR_AGENT_VERSION=latest
+OL_SCALYR_AGENT_VERSION=2.1.34-alpine
 
 #The VIRTUAL_HOST below is wrong, but we don't actually seem to use its value.
 #It may be relivent/used within the Core's version of the reporting stack because it

--- a/deployment/test_env/docker-compose.yml
+++ b/deployment/test_env/docker-compose.yml
@@ -246,7 +246,7 @@ services:
       - consul
 
   scalyr:
-    image: openlmis/scalyr
+    image: openlmis/scalyr${OL_SCALYR_AGENT_VERSION}
     container_name: scalyr-agent
     env_file: settings.env
     volumes:


### PR DESCRIPTION
The old version stopped working due to TLS errors.